### PR TITLE
Tweaks to Jupyter notebook

### DIFF
--- a/text-classifier/README.md
+++ b/text-classifier/README.md
@@ -6,7 +6,7 @@ More details about this example can be found in [the associated blog post](http:
 
 ## Setup
 
-1. Get a free SigOpt account at https://sigopt.com/signup
+1. Get a free SigOpt account at [https://sigopt.com/signup](https://sigopt.com/signup)
 2. Find your `client_token` on your [user profile](https://sigopt.com/user/profile).
 3. Insert your `client_token` into sigopt_creds.py
 4. `git clone https://github.com/sigopt/sigopt-examples.git`
@@ -15,12 +15,16 @@ More details about this example can be found in [the associated blog post](http:
 
 ## Run
 
+We recommend using [Jupyter](http://jupyter.readthedocs.org/en/latest/install.html) to walk through this example. Start Jupyter (run `jupyter notebook`), then open:
+
+[`SigOpt Text Classifier Walkthrough.ipynb`](https://github.com/sigopt/sigopt-examples/blob/master/text-classifier/SigOpt%20Text%20Classifier%20Walkthrough.ipynb)
+
+The classifier tuning can also be run without Jupyter with this command:
+
 ```
 nohup python sentiment_classifier.py &
 ```
 
-You can track the progress on your [experiment dashboard](https://sigopt.com/experiment/list).
+## Optimize
 
-## Walkthrough
-
-If you'd like to go more in depth with the code, step through our Jupyter notebook [walkthrough](https://github.com/sigopt/sigopt-examples/blob/master/text-classifier/SigOpt%20Text%20Classifier%20Walkthrough.ipynb).
+Once the text classifier model tuning loop is running, you can track the progress on your [experiment dashboard](https://sigopt.com/experiment/list).

--- a/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
+++ b/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# SigOpt for ML: Automatically Tuning Text Classifiers Walkthrough\n",
-    "*This notebook is a walkthrough companion for our blog post [SigOpt for ML: Automatically Tuning Text Classifiers](http://blog.sigopt.com/post/133089144983/sigopt-for-ml-automatically-tuning-text) by Research Engineer [Ian Dewancker](https://sigopt.com/about#ian)*\n",
+    "*This <a href=\"http://jupyter.readthedocs.org/en/latest/install.html\">Jupyter notebook</a> is a walkthrough companion for our blog post [SigOpt for ML: Automatically Tuning Text Classifiers](http://blog.sigopt.com/post/133089144983/sigopt-for-ml-automatically-tuning-text) by Research Engineer [Ian Dewancker](https://sigopt.com/about#ian)*\n",
     "\n",
     "Text classification problems appear quite often in modern information systems, and you might imagine building a small document/tweet/blogpost classifier for any number of purposes. In this example, we're building a pipeline to label [Amazon product reviews](http://www.cs.jhu.edu/~mdredze/datasets/sentiment/) as either favorable or not. First, we'll use scikit-learn to build a logistic regression classifier, performing k-fold cross validation to measure the accuracy. Next, we'll use SigOpt to tune the hyperparameters of both the feature extraction and the model building. \n",
     "## Setup\n",
@@ -25,18 +25,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "POSITIVE: My husband is a BMW mechanic and he drives cars all day.  I wish I could get him one for every car\n",
-      "\n",
-      "NEGATIVE: Far better models for similair price range - dissapointed with the quality of the finish etc etc. works fine though.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import json\n",
     "POSITIVE_TEXT = json.load(open(\"POSITIVE_list.json\"))\n",
@@ -116,15 +105,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Mean of 5-folded cross-validation accuracies: 0.839165419162\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from sklearn import cross_validation\n",
     "cv_split = cross_validation.ShuffleSplit(\n",
@@ -168,16 +149,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Default parameters of vectorizer: {\"ngram_range\": [1, 1], \"max_df\": 1.0, \"min_df\": 1}\n",
-      "Default parameters of classifier: {\"alpha\": 0.0001, \"l1_ratio\": 0.15}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print \"Default parameters of vectorizer: {}\".format(json.dumps({\n",
     "    'min_df': vectorizer.min_df,\n",
@@ -238,15 +210,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "View your experiment details at https://sigopt.com/experiment/2309\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import math\n",
     "experiment = conn.experiments().create(\n",
@@ -349,6 +313,7 @@
    "outputs": [],
    "source": [
     "for _ in range(60):\n",
+    "    print \"Training model candidate {0}\".format(_)\n",
     "    suggestion = conn.experiments(experiment.id).suggestions().create()\n",
     "    opt_metric = sentiment_metric(POSITIVE_TEXT, NEGATIVE_TEXT, suggestion.assignments)\n",
     "    conn.experiments(experiment.id).observations().create(\n",
@@ -384,24 +349,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Best value: 0.87939745509, found at:\n",
-      "{\n",
-      "    \"df_offset\": 0.25,\n",
-      "    \"l1_coef\": 0.0,\n",
-      "    \"log_min_df\": -13.7549373592,\n",
-      "    \"log_reg_coef\": -7.57584670925,\n",
-      "    \"min_ngram\": 1,\n",
-      "    \"ngram_offset\": 1\n",
-      "}\n",
-      "View your final results at https://sigopt.com/experiment/2309\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "best_observation = experiment.progress.best_observation\n",
     "print \"Best value: {value}, found at:\\n{assignments}\".format(\n",

--- a/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
+++ b/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
@@ -25,7 +25,18 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "POSITIVE: My husband is a BMW mechanic and he drives cars all day.  I wish I could get him one for every car\n",
+      "\n",
+      "NEGATIVE: Far better models for similair price range - dissapointed with the quality of the finish etc etc. works fine though.\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "POSITIVE_TEXT = json.load(open(\"POSITIVE_list.json\"))\n",
@@ -105,7 +116,15 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean of 5-folded cross-validation accuracies: 0.839165419162\n"
+     ]
+    }
+   ],
    "source": [
     "from sklearn import cross_validation\n",
     "cv_split = cross_validation.ShuffleSplit(\n",
@@ -149,7 +168,16 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default parameters of vectorizer: {\"ngram_range\": [1, 1], \"max_df\": 1.0, \"min_df\": 1}\n",
+      "Default parameters of classifier: {\"alpha\": 0.0001, \"l1_ratio\": 0.15}\n"
+     ]
+    }
+   ],
    "source": [
     "print \"Default parameters of vectorizer: {}\".format(json.dumps({\n",
     "    'min_df': vectorizer.min_df,\n",
@@ -349,7 +377,24 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Best value: 0.87939745509, found at:\n",
+      "{\n",
+      "    \"df_offset\": 0.25,\n",
+      "    \"l1_coef\": 0.0,\n",
+      "    \"log_min_df\": -13.7549373592,\n",
+      "    \"log_reg_coef\": -7.57584670925,\n",
+      "    \"min_ngram\": 1,\n",
+      "    \"ngram_offset\": 1\n",
+      "}\n",
+      "View your final results at https://sigopt.com/experiment/2309\n"
+     ]
+    }
+   ],
    "source": [
     "best_observation = experiment.progress.best_observation\n",
     "print \"Best value: {value}, found at:\\n{assignments}\".format(\n",

--- a/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
+++ b/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
@@ -312,8 +312,8 @@
    },
    "outputs": [],
    "source": [
-    "for _ in range(60):\n",
-    "    print \"Training model candidate {0}\".format(_)\n",
+    "for i in range(60):\n",
+    "    print \"Training model candidate {0}\".format(i)\n",
     "    suggestion = conn.experiments(experiment.id).suggestions().create()\n",
     "    opt_metric = sentiment_metric(POSITIVE_TEXT, NEGATIVE_TEXT, suggestion.assignments)\n",
     "    conn.experiments(experiment.id).observations().create(\n",

--- a/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
+++ b/text-classifier/SigOpt Text Classifier Walkthrough.ipynb
@@ -377,22 +377,7 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Best value: 0.87939745509, found at:\n",
-      "{\n",
-      "    \"df_offset\": 0.25,\n",
-      "    \"l1_coef\": 0.0,\n",
-      "    \"log_min_df\": -13.7549373592,\n",
-      "    \"log_reg_coef\": -7.57584670925,\n",
-      "    \"min_ngram\": 1,\n",
-      "    \"ngram_offset\": 1\n",
-      "}\n",
-      "View your final results at https://sigopt.com/experiment/2309\n"
-     ]
+   "outputs": []
     }
    ],
    "source": [


### PR DESCRIPTION
- Rearrange README to point to Jupyter.
- Add link to Jupyter install link to notebook.
- Add console output during 60 model training runs so it's clear something is happening.
- Remove the internal output from the external notebook (we don't want our internal numbers / experiment IDs / etc in the blank notebook)

cc @alexandraj777 