### PR TITLE
cloud_provider -> provider

### DIFF
--- a/orchestrate/clusters/cpu_cluster.yml
+++ b/orchestrate/clusters/cpu_cluster.yml
@@ -1,4 +1,4 @@
-cloud_provider: aws
+provider: aws
 cluster_name: cpu-cluster
 cpu:
   min_nodes: 1

--- a/orchestrate/clusters/gpu_cluster.yml
+++ b/orchestrate/clusters/gpu_cluster.yml
@@ -1,4 +1,4 @@
-cloud_provider: aws
+provider: aws
 cluster_name: gpu-cluster
 gpu:
   min_nodes: 1

--- a/orchestrate/clusters/hybrid_cluster.yml
+++ b/orchestrate/clusters/hybrid_cluster.yml
@@ -1,4 +1,4 @@
-cloud_provider: aws
+provider: aws
 cluster_name: cpu-gpu-cluster
 cpu:
   min_nodes: 1

--- a/orchestrate/clusters/i3_cluster.yml
+++ b/orchestrate/clusters/i3_cluster.yml
@@ -1,4 +1,4 @@
-cloud_provider: aws
+provider: aws
 cluster_name: i3-cluster
 cpu:
   instance_type: i3.large

--- a/orchestrate/clusters/tiny_cluster.yml
+++ b/orchestrate/clusters/tiny_cluster.yml
@@ -1,4 +1,4 @@
-cloud_provider: aws
+provider: aws
 cluster_name: tiny-cluster
 cpu:
   instance_type: t2.small

--- a/orchestrate/clusters/travis_test.yml
+++ b/orchestrate/clusters/travis_test.yml
@@ -1,4 +1,4 @@
-cloud_provider: aws
+provider: aws
 cluster_name: travis-test
 cpu:
   instance_type: t2.small


### PR DESCRIPTION
I was trying to do something tricky for a while by batching up naming changes until the 0.3.0 release, and kindof storing docs changes in a branch somehwere.  At @taylorjacklespriggs's suggestion some weeks back, though, these fields will just continue to live in parallel without breaking the old field until the 0.3.0 (when `cloud_provider` will be deprecated and removed). A benefit is that since the `provider` field is up and running now, we can change over the docs before the 0.3.0 release